### PR TITLE
optimized tor args, and force change circuits via tor control port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,12 @@ RUN gem install excon -v 0.44.4
 ADD start.rb /usr/local/bin/start.rb
 RUN chmod +x /usr/local/bin/start.rb
 
-ADD haproxy.cfg.erb /usr/local/etc/haproxy.cfg.erb
+ADD newnym.sh /usr/local/bin/newnym.sh
+RUN chmod +x /usr/local/bin/newnym.sh
 
-EXPOSE 5566 1936
+ADD haproxy.cfg.erb /usr/local/etc/haproxy.cfg.erb
+ADD uncachable /etc/polipo/uncachable
+
+EXPOSE 5566 4444
 
 CMD /usr/local/bin/start.rb

--- a/haproxy.cfg.erb
+++ b/haproxy.cfg.erb
@@ -14,7 +14,7 @@ defaults
   timeout server 60s
 
 
-listen stats *:1936
+listen stats *:4444
   mode            http
   log             global
   maxconn 10

--- a/newnym.sh
+++ b/newnym.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CONTROLPORT=$1
+
+cat <<'EOF' | nc localhost $CONTROLPORT
+authenticate ""
+signal newnym
+quit
+EOF

--- a/start.rb
+++ b/start.rb
@@ -83,6 +83,13 @@ module Service
 
 
   class Tor < Base
+    attr_reader :port, :control_port
+
+    def initialize(port, control_port)
+        @port = port
+        @control_port = control_port
+    end
+
     def data_directory
       "#{super}/#{port}"
     end
@@ -91,12 +98,28 @@ module Service
       super
       self.class.fire_and_forget(executable,
         "--SocksPort #{port}",
-        "--NewCircuitPeriod 120",
+	"--ControlPort #{control_port}",
+        "--NewCircuitPeriod 15",
+	"--MaxCircuitDirtiness 15",
+	"--NumEntryGuards 8",
+	"--CircuitBuildTimeout 5",
+	"--ExitNodes {us}",
+	"--ExitRelay 0",
+	"--RefuseUnknownExits 0",
+	"--ClientOnly 1",
+	"--StrictNodes 1",
+	"--AllowSingleHopCircuits 1",
         "--DataDirectory #{data_directory}",
         "--PidFile #{pid_file}",
         "--Log \"warn syslog\"",
         '--RunAsDaemon 1',
         "| logger -t 'tor' 2>&1")
+    end
+
+    def newnym
+        self.class.fire_and_forget('/usr/local/bin/newnym.sh',
+				   "#{control_port}",
+				   "| logger -t 'newnym' 2>&1")
     end
   end
 
@@ -142,7 +165,7 @@ module Service
 
     def initialize(id)
       @id = id
-      @tor = Tor.new(tor_port)
+      @tor = Tor.new(tor_port, tor_control_port)
       @polipo = Polipo.new(polipo_port, tor: tor)
     end
 
@@ -168,17 +191,21 @@ module Service
       10000 + id
     end
 
+    def tor_control_port
+      30000 + id
+    end
+
     def polipo_port
       tor_port + 10000
     end
     alias_method :port, :polipo_port
 
     def test_url
-      ENV['test_url'] || 'http://echoip.com'
+      ENV['test_url'] || 'http://icanhazip.com'
     end
 
     def working?
-      Excon.get(test_url, proxy: "http://127.0.0.1:#{port}").status == 200
+      Excon.get(test_url, proxy: "http://127.0.0.1:#{port}", :read_timeout => 10).status == 200
     rescue
       false
     end
@@ -221,7 +248,6 @@ module Service
   end
 end
 
-
 haproxy = Service::Haproxy.new
 proxies = []
 
@@ -238,12 +264,18 @@ haproxy.start
 sleep 60
 
 loop do
+  $logger.info "resetting circuits"
+  proxies.each do |proxy|
+    $logger.info "reset nym for #{proxy.id} (port #{proxy.port})"
+    proxy.tor.newnym
+  end
+
   $logger.info "testing proxies"
   proxies.each do |proxy|
     $logger.info "testing proxy #{proxy.id} (port #{proxy.port})"
     proxy.restart unless proxy.working?
   end
 
-  $logger.info "sleeping for 1800 seconds"
-  sleep 1800
+  $logger.info "sleeping for 60 seconds"
+  sleep 60
 end

--- a/start.rb
+++ b/start.rb
@@ -101,13 +101,12 @@ module Service
 	"--ControlPort #{control_port}",
         "--NewCircuitPeriod 15",
 	"--MaxCircuitDirtiness 15",
-	"--NumEntryGuards 8",
+	"--UseEntryGuards 0",
+	"--UseEntryGuardsAsDirGuards 0",
 	"--CircuitBuildTimeout 5",
-	"--ExitNodes {us}",
 	"--ExitRelay 0",
 	"--RefuseUnknownExits 0",
 	"--ClientOnly 1",
-	"--StrictNodes 1",
 	"--AllowSingleHopCircuits 1",
         "--DataDirectory #{data_directory}",
         "--PidFile #{pid_file}",
@@ -119,7 +118,7 @@ module Service
     def newnym
         self.class.fire_and_forget('/usr/local/bin/newnym.sh',
 				   "#{control_port}",
-				   "| logger -t 'newnym' 2>&1")
+				   "| logger -t 'newnym'")
     end
   end
 

--- a/uncachable
+++ b/uncachable
@@ -1,0 +1,3 @@
+ipinfo.io
+icanhazip.com
+echoip.com


### PR DESCRIPTION
In my testing, I was getting a very limited subset of IP addresses from Tor. This pull request fixes that issue.

Major improvements:
- Tor args changed to refresh circuits as often as possible
- Control port enabled for each tor instance (from: https://www.thesprawl.org/research/tor-control-protocol)
- Loop added to main execution of `start.rb` to reset circuit of each tor instance via control port using `newnym.sh` script
- `uncachable` file including common IP checking websites so you can see IP is actually changing
- `Proxy.working?` includes a timeout so the whole script does not hang for 60 seconds (default timeout)

Changes you might not want:
- USA only exit nodes
- haproxy stats port 4444
