### PR TITLE
Updating package to stay relevant in 2022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM ubuntu:14.04
-MAINTAINER Matthias Kadenbach <matthias.kadenbach@gmail.com>
-
-RUN echo 'deb http://deb.torproject.org/torproject.org trusty main' | tee /etc/apt/sources.list.d/torproject.list
-RUN gpg --keyserver keys.gnupg.net --recv 886DDD89
-RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
-
-RUN echo 'deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main' | tee /etc/apt/sources.list.d/ruby.list
-RUN gpg --keyserver keyserver.ubuntu.com --recv C3173AA6
-RUN gpg --export 80f70e11f0f0d5f10cb20e62f5da5f09c3173aa6 | apt-key add -
+FROM ubuntu:22.04
+LABEL org.opencontainers.image.authors="matthias.kadenbach@gmail.com"
 
 RUN apt-get update && \
-    apt-get install -y tor polipo haproxy ruby2.1 libssl-dev wget curl build-essential zlib1g-dev libyaml-dev libssl-dev && \
+    apt-get install -y tor haproxy ruby-full libssl-dev wget curl build-essential zlib1g-dev libyaml-dev libssl-dev netcat && \
     ln -s /lib/x86_64-linux-gnu/libssl.so.1.0.0 /lib/libssl.so.1.0.0
+
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/p/polipo/polipo_1.1.1-8_amd64.deb
+RUN dpkg -i polipo_1.1.1-8_amd64.deb
 
 RUN update-rc.d -f tor remove
 RUN update-rc.d -f polipo remove

--- a/haproxy.cfg.erb
+++ b/haproxy.cfg.erb
@@ -14,14 +14,15 @@ defaults
   timeout server 60s
 
 
-listen stats *:4444
+listen stats
+  bind *:4444
   mode            http
   log             global
   maxconn 10
-  clitimeout      100s
-  srvtimeout      100s
-  contimeout      100s
-  timeout queue   100s
+  timeout client      100s
+  timeout server      100s
+  timeout connect     100s
+  timeout queue       100s
   stats enable
   stats hide-version
   stats refresh 30s
@@ -35,7 +36,6 @@ frontend rotating_proxies
   option http_proxy
 
 backend tor
-  option http_proxy
   balance leastconn # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#balance
 
   <% backends.each do |b| %>


### PR DESCRIPTION
First of all, thank you so much for the amazing work that has saved my team a significant amount of time and resources.
Ubuntu 14 doesn't look like the best solution in 2022, so I suggest updating your project to the current version.
In the proposed configuration, an active test was carried out in operation and no problems were identified.